### PR TITLE
fix: remove unsupported TypeScript features

### DIFF
--- a/src/main/webapp/static/ts/datasource-controller.ts
+++ b/src/main/webapp/static/ts/datasource-controller.ts
@@ -124,7 +124,7 @@ module demo {
         this.showMessage('Datasource salvato con successo', 'success');
       }).catch((error) => {
         this.scope.isLoading = false;
-        this.scope.message = error.data?.message || 'Errore durante il salvataggio';
+        this.scope.message = (error.data && error.data.message) || 'Errore durante il salvataggio';
         this.scope.messageType = 'error';
       });
     }
@@ -143,7 +143,7 @@ module demo {
         this.scope.showTestDialog = true;
       }).catch((error) => {
         this.scope.isLoading = false;
-        this.scope.testResult = { ok: false, error: error.data?.message || 'Test connessione fallito' };
+        this.scope.testResult = { ok: false, error: (error.data && error.data.message) || 'Test connessione fallito' };
         this.scope.showTestDialog = true;
       });
     }
@@ -163,7 +163,7 @@ module demo {
         this.showMessage('Datasource eliminato con successo', 'success');
       }).catch((error) => {
         this.scope.isLoading = false;
-        this.showMessage(error.data?.message || 'Errore durante l\'eliminazione', 'error');
+        this.showMessage((error.data && error.data.message) || 'Errore durante l\'eliminazione', 'error');
       });
     }
 

--- a/src/main/webapp/static/ts/datasource-service.ts
+++ b/src/main/webapp/static/ts/datasource-service.ts
@@ -2,7 +2,7 @@
 
 module demo {
   export interface IDatasource {
-    id: number | null;
+    id: number;
     sourceName: string;
     appName: string;
     property: string;


### PR DESCRIPTION
## Summary
- replace optional chaining with legacy null checks for TypeScript 1.6
- simplify datasource interface to avoid null union type

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM (network unreachable))*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a6ed871f1083329fc68a9536c657e8