### PR TITLE
refactor: use angular namespace for typings

### DIFF
--- a/src/main/webapp/static/ts/about-controller.ts
+++ b/src/main/webapp/static/ts/about-controller.ts
@@ -1,7 +1,7 @@
 /// <reference path="../typings/angularjs/angular.d.ts" />
 
 module demo {
-  interface IAboutScope extends ng.IScope {
+  interface IAboutScope extends angular.IScope {
     appInfo: any;
   }
   

--- a/src/main/webapp/static/ts/angularjs-demo-app.ts
+++ b/src/main/webapp/static/ts/angularjs-demo-app.ts
@@ -10,7 +10,7 @@
 
 var demoApp = angular.module('demo', ['ngRoute']);
 
-demoApp.config(['$routeProvider', function($routeProvider: ng.route.IRouteProvider) {
+demoApp.config(['$routeProvider', function($routeProvider: angular.route.IRouteProvider) {
   $routeProvider
     .when('/', {
       templateUrl: 'views/home.html',

--- a/src/main/webapp/static/ts/angularjs-demo-controller.ts
+++ b/src/main/webapp/static/ts/angularjs-demo-controller.ts
@@ -2,7 +2,7 @@
 /// <reference path="angularjs-demo-service.ts" />
 
 module demo {
-  interface IDemoScope extends ng.IScope {
+  interface IDemoScope extends angular.IScope {
     person: IPerson;
     fetchPerson: () => void;
   }

--- a/src/main/webapp/static/ts/angularjs-demo-service.ts
+++ b/src/main/webapp/static/ts/angularjs-demo-service.ts
@@ -16,37 +16,37 @@ module demo {
   
   export class DemoService {
     static $inject = ['$http'];
-    private httpService: ng.IHttpService;
+    private httpService: angular.IHttpService;
 
-    constructor($http: ng.IHttpService) {
+    constructor($http: angular.IHttpService) {
       this.httpService = $http;
     }
 
-    getPerson(): ng.IPromise<IPerson> {
+    getPerson(): angular.IPromise<IPerson> {
       return this.httpService.get<IPerson>('api/person').then((response) => {
         return response.data;
       });
     }
     
-    getUsers(): ng.IPromise<IUser[]> {
+    getUsers(): angular.IPromise<IUser[]> {
       return this.httpService.get<IUser[]>('api/users').then((response) => {
         return response.data;
       });
     }
     
-    addUser(user: IPerson): ng.IPromise<IUser> {
+    addUser(user: IPerson): angular.IPromise<IUser> {
       return this.httpService.post<IUser>('api/users', user).then((response) => {
         return response.data;
       });
     }
     
-    deleteUser(userId: number): ng.IPromise<void> {
+    deleteUser(userId: number): angular.IPromise<void> {
       return this.httpService.delete<void>('api/users/' + userId).then(() => {
         return;
       });
     }
     
-    getRandomPeople(): ng.IPromise<IPerson[]> {
+    getRandomPeople(): angular.IPromise<IPerson[]> {
       return this.httpService.get<IPerson[]>('api/people/random').then((response) => {
         return response.data;
       });

--- a/src/main/webapp/static/ts/contact-controller.ts
+++ b/src/main/webapp/static/ts/contact-controller.ts
@@ -1,7 +1,7 @@
 /// <reference path="../typings/angularjs/angular.d.ts" />
 
 module demo {
-  interface IContactScope extends ng.IScope {
+  interface IContactScope extends angular.IScope {
     contact: any;
     submitForm: () => void;
     message: string;

--- a/src/main/webapp/static/ts/datasource-controller.ts
+++ b/src/main/webapp/static/ts/datasource-controller.ts
@@ -2,7 +2,7 @@
 /// <reference path="datasource-service.ts" />
 
 module demo {
-  interface IDatasourceScope extends ng.IScope {
+  interface IDatasourceScope extends angular.IScope {
     datasources: IDatasource[];
     searchQuery: string;
     currentPage: number;

--- a/src/main/webapp/static/ts/datasource-service.ts
+++ b/src/main/webapp/static/ts/datasource-service.ts
@@ -23,13 +23,13 @@ module demo {
   
   export class DatasourceService {
     static $inject = ['$http'];
-    private httpService: ng.IHttpService;
+    private httpService: angular.IHttpService;
 
-    constructor($http: ng.IHttpService) {
+    constructor($http: angular.IHttpService) {
       this.httpService = $http;
     }
 
-    getDatasources(page: number = 1, pageSize: number = 25, query: string = ''): ng.IPromise<IDatasourceListResponse> {
+    getDatasources(page: number = 1, pageSize: number = 25, query: string = ''): angular.IPromise<IDatasourceListResponse> {
       let url = `api/datasources?page=${page}&pageSize=${pageSize}`;
       if (query) {
         url += `&q=${encodeURIComponent(query)}`;
@@ -40,37 +40,37 @@ module demo {
       });
     }
     
-    createDatasource(datasource: IDatasource): ng.IPromise<IDatasource> {
+    createDatasource(datasource: IDatasource): angular.IPromise<IDatasource> {
       return this.httpService.post<IDatasource>('api/datasources', datasource).then((response) => {
         return response.data;
       });
     }
     
-    updateDatasource(datasource: IDatasource): ng.IPromise<IDatasource> {
+    updateDatasource(datasource: IDatasource): angular.IPromise<IDatasource> {
       return this.httpService.put<IDatasource>(`api/datasources/${datasource.id}`, datasource).then((response) => {
         return response.data;
       });
     }
     
-    deleteDatasource(datasourceId: number): ng.IPromise<void> {
+    deleteDatasource(datasourceId: number): angular.IPromise<void> {
       return this.httpService.delete<void>(`api/datasources/${datasourceId}`).then(() => {
         return;
       });
     }
     
-    testConnection(datasource: IDatasource): ng.IPromise<ITestResult> {
+    testConnection(datasource: IDatasource): angular.IPromise<ITestResult> {
       return this.httpService.post<ITestResult>('api/datasources/test', datasource).then((response) => {
         return response.data;
       });
     }
     
-    getPropertyOptions(): ng.IPromise<string[]> {
+    getPropertyOptions(): angular.IPromise<string[]> {
       return this.httpService.get<string[]>('api/datasources/properties').then((response) => {
         return response.data;
       });
     }
     
-    getApplicationOptions(): ng.IPromise<string[]> {
+    getApplicationOptions(): angular.IPromise<string[]> {
       return this.httpService.get<string[]>('api/datasources/applications').then((response) => {
         return response.data;
       });

--- a/src/main/webapp/static/ts/users-controller.ts
+++ b/src/main/webapp/static/ts/users-controller.ts
@@ -2,7 +2,7 @@
 /// <reference path="angularjs-demo-service.ts" />
 
 module demo {
-  interface IUsersScope extends ng.IScope {
+  interface IUsersScope extends angular.IScope {
     users: IPerson[];
     newUser: IPerson;
     addUser: () => void;

--- a/src/main/webapp/static/typings/angularjs/angular-route.d.ts
+++ b/src/main/webapp/static/typings/angularjs/angular-route.d.ts
@@ -9,7 +9,7 @@ declare module "angular-route" {
 ///////////////////////////////////////////////////////////////////////////////
 // ngRoute module (angular-route.js)
 ///////////////////////////////////////////////////////////////////////////////
-declare namespace ng.route {
+declare namespace angular.route {
 
     ///////////////////////////////////////////////////////////////////////////
     // RouteService
@@ -33,20 +33,20 @@ declare namespace ng.route {
     interface ICurrentRoute extends IRoute {
         locals: {
             [index: string]: any;
-            $scope: IScope;
+            $scope: angular.IScope;
             $template: string;
         };
 
         params: any;
         pathParams: any;
-        scope: IScope;
+        scope: angular.IScope;
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // RouteProvider
     // see http://docs.angularjs.org/api/ngRoute/provider/$routeProvider
     ///////////////////////////////////////////////////////////////////////////
-    interface IRouteProvider extends IServiceProvider {
+    interface IRouteProvider extends angular.IServiceProvider {
         when(path: string, route: IRoute): IRouteProvider;
         otherwise(params: IRoute): IRouteProvider;
     }
@@ -75,6 +75,6 @@ declare namespace ng.route {
 
 declare namespace angular {
     interface IModule {
-        config(fn: (routeProvider: ng.route.IRouteProvider, ...injectables: any[]) => any): IModule;
+        config(fn: (routeProvider: angular.route.IRouteProvider, ...injectables: any[]) => any): IModule;
     }
 }

--- a/src/main/webapp/static/typings/angularjs/angular.d.ts
+++ b/src/main/webapp/static/typings/angularjs/angular.d.ts
@@ -12,9 +12,6 @@ declare var angular: angular.IAngularStatic;
 interface Function {
     $inject?: string[];
 }
-
-// Collapse angular into ng
-import ng = angular;
 // Support AMD require
 declare module 'angular' {
     export = angular;


### PR DESCRIPTION
## Summary
- remove deprecated `ng` alias so Angular types are exported directly from `angular`
- rename route typings namespace to `angular.route`
- update demo TypeScript sources to use `angular.*` interfaces

## Testing
- `mvn -B -DskipTests package` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a6f260cc048332b70eb7f4019bb5da