### PR TITLE
Refactor Dockerfile COPY for finer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY pom.xml ./
 RUN mvn -B -DskipTests dependency:go-offline
 
 # Bring the rest of the source
-COPY src ./src
+COPY src/main/java ./src/main/java
 COPY src/main/webapp/static ./src/main/webapp/static
 
 # Node & tooling needed by the Grunt/Bower flow that Maven triggers


### PR DESCRIPTION
## Summary
- refine Dockerfile to copy backend and frontend sources separately for improved caching

## Testing
- `docker build -t spring-boot-angularjs-demo:test .` *(fails: command not found: docker)*
- `mvn -B -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:1.3.0.RELEASE)*

------
https://chatgpt.com/codex/tasks/task_b_68a6f2629d208332bb7067f555f57c3b