### PR TITLE
Configure Bower to allow root execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,9 @@
           <gruntOptions>
             <gruntOption>--verbose</gruntOption>
           </gruntOptions>
+          <bowerOptions>
+            <bowerOption>--allow-root</bowerOption>
+          </bowerOptions>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
## Summary
- Allow Bower to run as root by passing `--allow-root` through the grunt-maven-plugin configuration

## Testing
- `mvn -e -DskipTests package` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a6f263dce483328239baeaba774b5e